### PR TITLE
Fixing osbuilder-tools --local flag error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ overlay/installer/oem/userdata.yaml
 *.env
 provider-*/
 userdata
+*.zst
+overlay/files-iso-installer/opt/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 overlay/oem/userdata.yaml
 overlay/installer/oem/userdata.yaml
 *user-data.yaml
+*.env
+provider-*/
+userdata

--- a/build-installer.sh
+++ b/build-installer.sh
@@ -20,8 +20,8 @@ fi
 
 if [ ! -z $CONTENT_BUNDLE ]; then
   mkdir -p overlay/files-iso-installer/opt/spectrocloud/content
-  #cp $CONTENT_BUNDLE overlay/files-iso-installer/opt/spectrocloud/content/spectro-content.tar
-  zstd -19 -T0 -o overlay/files-iso-installer/opt/spectrocloud/content/spectro-content.tar.zst $CONTENT_BUNDLE
+  cp $CONTENT_BUNDLE overlay/files-iso-installer/opt/spectrocloud/content/
+  #zstd -19 -T0 -o overlay/files-iso-installer/opt/spectrocloud/content/spectro-content.tar.zst $CONTENT_BUNDLE
   #rm overlay/files-iso-installer/opt/spectrocloud/content/spectro-content.tar
 fi
 
@@ -30,7 +30,8 @@ echo "Building custom $IMAGE from $BASE_IMAGE"
 docker build --build-arg BASE_IMAGE=$BASE_IMAGE \
              -t $IMAGE \
              --platform $BUILD_PLATFORM \
-             -f images/Dockerfile.installer ./
+             -f images/Dockerfile.installer ./ \
+	     --no-cache
 
 
 echo "Building $ISO.iso from $IMAGE"

--- a/build-installer.sh
+++ b/build-installer.sh
@@ -13,12 +13,12 @@ IMAGE="${IMAGE_NAME}:${INSTALLER_VERSION}"
 USER_DATA_FILE="${USER_DATA_FILE:-user-data}"
 BUILD_PLATFORM="${BUILD_PLATFORM:-linux/amd64}"
 
-if [ -f $USER_DATA_FILE ]; then
+if [ ! -z $USER_DATA_FILE ]; then
  mkdir -p overlay/installer/oem
  cp $USER_DATA_FILE overlay/installer/oem/userdata.yaml
 fi
 
-if [ -f $CONTENT_BUNDLE ]; then
+if [ ! -z $CONTENT_BUNDLE ]; then
   mkdir -p overlay/files-iso-installer/opt/spectrocloud/content
   #cp $CONTENT_BUNDLE overlay/files-iso-installer/opt/spectrocloud/content/spectro-content.tar
   zstd -19 -T0 -o overlay/files-iso-installer/opt/spectrocloud/content/spectro-content.tar.zst $CONTENT_BUNDLE
@@ -36,7 +36,7 @@ docker build --build-arg BASE_IMAGE=$BASE_IMAGE \
 echo "Building $ISO.iso from $IMAGE"
 docker run -v "$PWD:/cOS" \
            -v /var/run/docker.sock:/var/run/docker.sock \
-           -i --rm quay.io/kairos/osbuilder-tools:latest build-iso \
+           -i --rm quay.io/kairos/osbuilder-tools:v0.7.11 build-iso \
              --name $ISO --debug --local  \
              --overlay-iso /cOS/overlay/files-iso-installer --output /cOS/ \
              $IMAGE


### PR DESCRIPTION
Pinning kairos `osbuilder-tools` version (`:latest` does not work anymore, due to latest kairos changes) and fixing `if -f` statement flag for both content-bundle and user-data in build-installer script, with `if ! -z`, i.e., check if the env variables exist or are unset/empty